### PR TITLE
Ensure firewalld is not attempted on el6

### DIFF
--- a/libraries/provider_firewall_firewalld.rb
+++ b/libraries/provider_firewall_firewalld.rb
@@ -19,7 +19,9 @@ class Chef
   class Provider::FirewallFirewalld < Chef::Provider::LWRPBase
     include FirewallCookbook::Helpers::Firewalld
 
-    provides :firewall, os: 'linux', platform_family: %w(rhel fedora)
+    provides :firewall, os: 'linux', platform_family: %w(rhel fedora) do |node|
+      node['platform_version'].to_f >= 7.0
+    end
 
     def whyrun_supported?
       false


### PR DESCRIPTION
I'm seeing an issue were chef provider selection appears to be non-deterministic, depending on whether the `firewalld` or `iptables` provider is checked first.

This resulted in `firewalld` trying to install on EL6 machines.

The included patch ensures that there is no overlap in provider selection.