### PR TITLE
Also ensure firewalld_rule is not attempted on el6

### DIFF
--- a/libraries/provider_firewall_rule_firewalld.rb
+++ b/libraries/provider_firewall_rule_firewalld.rb
@@ -21,7 +21,9 @@ class Chef
   class Provider::FirewallRuleFirewalld < Chef::Provider::LWRPBase
     include FirewallCookbook::Helpers::Firewalld
 
-    provides :firewall_rule, os: 'linux', platform_family: %w(rhel fedora)
+    provides :firewall_rule, os: 'linux', platform_family: %w(rhel fedora) do |node|
+      node['platform_version'].to_f >= 7.0
+    end
 
     action :create do
       firewall = run_context.resource_collection.find(firewall: new_resource.firewall_name)


### PR DESCRIPTION
In hindsight, it seems a bit daft that I missed this before.

The impact for us this time was pretty bad - the `firewall` resource selected `iptables`, but the `firewall_rule` resource selected `firewalld`!

I managed to limit the impact to a single node and debug via whyrun & logs:

```
Recipe: firewall::default
  * firewall[default] action install
    * Whyrun not supported for firewall[default], bypassing load.
     (Skipped: whyrun not supported by provider Chef::Provider::FirewallIptables)

  * firewall_rule[all_tcp] action create
    * Whyrun not supported for firewall_rule[all_tcp], bypassing load.
     (Skipped: whyrun not supported by provider Chef::Provider::FirewallRuleFirewalld)
```

I saw this in the log:
```
[2015-10-05T20:17:15+00:00] WARN: Ambiguous provider precedence: [Chef::Provider::FirewallRuleFirewalld, Chef::Provider::FirewallRuleIptables], please use Chef.set_provider_priority_array to provide determinism
```

This was with Chef 12.3.0, upgrading to 12.4.3 resolved the issue.