### PR TITLE
Add support for using iptables in RHEL 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,7 +36,6 @@ suites:
     excludes:
       - centos-5.11
       - centos-6.7
-      - centos-7.1
       - debian-7.8
       - debian-8.1
       - windows-2012r2
@@ -45,3 +44,4 @@ suites:
     attributes:
       firewall:
         ubuntu_iptables: true
+        redhat7_iptables: true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ By default, Ubuntu chooses ufw. To switch to iptables, set this in an attribute 
 default['firewall']['ubuntu_iptables'] = true
 ```
 
+By default, Red Hat & CentOS >= 7.0 chooses firewalld. To switch to iptables, set this in an attribute file:
+```
+default['firewall']['redhat7_iptables'] = true
+```
+
 # Read this first
 
 This cookbook comes with two resources, firewall and firewall rule. The typical usage scenario is as follows:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default['firewall']['allow_ssh'] = false
 default['firewall']['allow_winrm'] = false
 default['firewall']['ubuntu_iptables'] = false
+default['firewall']['redhat7_iptables'] = false
 default['firewall']['allow_established'] = true
 default['firewall']['ipv6_enabled'] = true

--- a/libraries/provider_firewall_firewalld.rb
+++ b/libraries/provider_firewall_firewalld.rb
@@ -20,7 +20,7 @@ class Chef
     include FirewallCookbook::Helpers::Firewalld
 
     provides :firewall, os: 'linux', platform_family: %w(rhel fedora) do |node|
-      node['platform_version'].to_f >= 7.0
+      node['platform_version'].to_f >= 7.0 && !node['firewall']['redhat7_iptables']
     end
 
     def whyrun_supported?

--- a/libraries/provider_firewall_iptables.rb
+++ b/libraries/provider_firewall_iptables.rb
@@ -23,7 +23,7 @@ class Chef
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall, os: 'linux', platform_family: %w(rhel fedora) do |node|
-      node['platform_version'].to_f < 7.0
+      node['platform_version'].to_f < 7.0 || node['firewall']['redhat7_iptables']
     end
 
     def whyrun_supported?

--- a/libraries/provider_firewall_rule_firewalld.rb
+++ b/libraries/provider_firewall_rule_firewalld.rb
@@ -22,7 +22,7 @@ class Chef
     include FirewallCookbook::Helpers::Firewalld
 
     provides :firewall_rule, os: 'linux', platform_family: %w(rhel fedora) do |node|
-      node['platform_version'].to_f >= 7.0
+      node['platform_version'].to_f >= 7.0 && !node['firewall']['redhat7_iptables']
     end
 
     action :create do

--- a/libraries/provider_firewall_rule_iptables.rb
+++ b/libraries/provider_firewall_rule_iptables.rb
@@ -20,7 +20,7 @@ class Chef
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall_rule, os: 'linux', platform_family: %w(rhel fedora) do |node|
-      node['platform_version'].to_f < 7.0
+      node['platform_version'].to_f < 7.0 || node['firewall']['redhat7_iptables']
     end
 
     action :create do

--- a/test/integration/iptables/serverspec/iptables_redhat_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_redhat_spec.rb
@@ -1,0 +1,54 @@
+# these tests only for redhat with iptables
+require 'spec_helper'
+
+expected_rules = [
+  # we included the .*-j so that we don't bother testing comments
+  %r{-A INPUT -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT -p vrrp .*-j ACCEPT},
+  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
+]
+
+expected_ipv6_rules = [
+  %r{-A INPUT( -s ::/0 -d ::/0)? -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
+  %r{-A INPUT.* -p ipv6-icmp .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p vrrp .*-j ACCEPT},
+  %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
+]
+
+describe command('iptables-save'), if: redhat? do
+  its(:stdout) { should match(/COMMIT/) }
+
+  expected_rules.each do |r|
+    its(:stdout) { should match(r) }
+  end
+
+  # we try to get firewall to add this rule twice, but we expect to see it once!
+  duplicate_rule1 = '-A INPUT -p tcp -m tcp -m multiport --dports 1111 -m comment --comment "same comment" -j ACCEPT'
+  its(:stdout) { should count_occurences(duplicate_rule1, 1) }
+
+  duplicate_rule2 = '-A INPUT -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment "same comment" -j ACCEPT'
+  its(:stdout) { should count_occurences(duplicate_rule2, 1) }
+end
+
+describe command('ip6tables-save'), if: redhat? do
+  its(:stdout) { should match(/COMMIT/) }
+
+  expected_ipv6_rules.each do |r|
+    its(:stdout) { should match(r) }
+  end
+end
+
+describe service('iptables'), if: redhat? do
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
@@ -20,7 +20,7 @@ expected_ipv6_rules = [
   %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
 ]
 
-describe command('iptables-save') do
+describe command('iptables-save'), if: ubuntu? do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_rules.each do |r|
@@ -28,7 +28,7 @@ describe command('iptables-save') do
   end
 end
 
-describe command('ip6tables-save') do
+describe command('ip6tables-save'), if: ubuntu? do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_ipv6_rules.each do |r|
@@ -36,11 +36,11 @@ describe command('ip6tables-save') do
   end
 end
 
-describe service('iptables-persistent') do
+describe service('iptables-persistent'), if: ubuntu? do
   it { should be_enabled }
 end
 
-describe file('/etc/iptables/rules.v4') do
+describe file('/etc/iptables/rules.v4'), if: ubuntu? do
   it { should be_file }
 
   expected_rules.each do |r|
@@ -48,7 +48,7 @@ describe file('/etc/iptables/rules.v4') do
   end
 end
 
-describe file('/etc/iptables/rules.v6') do
+describe file('/etc/iptables/rules.v6'), if: ubuntu? do
   it { should be_file }
 
   expected_ipv6_rules.each do |r|


### PR DESCRIPTION
Much like Ubuntu users may want to use iptables in place of UFW, we've found that maintaining parity between our older RHEL/CentOS machines and RHEL 7 is difficult with the added complexity of firewalld.  This PR adds an option to fallback to iptables for RHEL 7/CentOS 7 as well.  The iptables support behaves essentially the same as earlier CentOS versions, so should not require any additional future maintenance burden.