### PR TITLE
Fixed the issue creating a firewall rule for windows with 'program' set to 'any' is invalid

### DIFF
--- a/libraries/helpers_windows.rb
+++ b/libraries/helpers_windows.rb
@@ -59,9 +59,7 @@ module FirewallCookbook
         parameters['description'] = "\"#{new_resource.description}\""
         parameters['dir'] = new_resource.direction
 
-        if new_resource.program
-          parameters['program'] = new_resource.program
-        end
+        new_resource.program && parameters['program'] = new_resource.program
         parameters['service'] = new_resource.service ? new_resource.service : 'any'
         parameters['protocol'] = new_resource.protocol
 


### PR DESCRIPTION
Windows adv firewall consider no 'program' parameter specified as the 'Any' option:

Usage: add rule name=<string>
      dir=in|out
      action=allow|block|bypass
      [program=<program path>]
      [service=<service short name>|any]
      [description=<string>]
      [enable=yes|no (default=yes)]
      [profile=public|private|domain|any[,...]]

if we put 'any' here, the firewall rule will not work as expected.