### PR TITLE
Fix the `port_to_s` function so it also works for Windows

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -5,12 +5,19 @@ module FirewallCookbook
     end
 
     def port_to_s(p)
-      if p && p.is_a?(Integer)
+      if p.is_a?(String)
+        p
+      elsif p && p.is_a?(Integer)
         p.to_s
       elsif p && p.is_a?(Array)
+        p.map! { |o| port_to_s(o) }
         p.sort.join(',')
       elsif p && p.is_a?(Range)
-        "#{p.first}:#{p.last}"
+        if platform_family?('windows')
+          "#{p.first}-#{p.last}"
+        else
+          "#{p.first}:#{p.last}"
+        end
       end
     end
 

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -75,3 +75,13 @@ firewall_rule 'ipv6-source' do
   source '2001:db8::ff00:42:8329'
   command :allow
 end
+
+firewall_rule 'range' do
+  port 1000..1100
+  command :allow
+end
+
+firewall_rule 'array' do
+  port [1234, 5000..5100, '5678']
+  command :allow
+end

--- a/test/integration/default/serverspec/firewalld_spec.rb
+++ b/test/integration/default/serverspec/firewalld_spec.rb
@@ -14,6 +14,8 @@ expected_rules = [
   %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv4 filter INPUT 49 -s 192.168.99.99/32 -p tcp -m tcp -m comment --comment block-192.168.99.99 -j REJECT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1000:1100 -m comment --comment range -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1234,5000:5100,5678 -m comment --comment array -j ACCEPT},
   # ipv6
   %r{ipv6 filter INPUT 50 -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
   %r{ipv6 filter INPUT 50 -p ipv6-icmp -m comment --comment ipv6_icmp -j ACCEPT},
@@ -26,7 +28,9 @@ expected_rules = [
   %r{ipv6 filter INPUT 50 -p 112 -m comment --comment protocolnum -j ACCEPT},
   %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1111 -m comment --comment 'same comment' -j ACCEPT},
   %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment 'same comment' -j ACCEPT},
-  %r{ipv6 filter INPUT 50 -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 -m comment --comment ipv6-source -j ACCEPT}
+  %r{ipv6 filter INPUT 50 -s 2001:db8::ff00:42:8329/128 -p tcp -m tcp -m multiport --dports 80 -m comment --comment ipv6-source -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1000:1100 -m comment --comment range -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1234,5000:5100,5678 -m comment --comment array -j ACCEPT}
 ]
 
 describe command('firewall-cmd --permanent --direct --get-all-rules'), if: firewalld? do

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -10,7 +10,9 @@ expected_rules = [
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp-port-unreachable},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
   %r{-A INPUT -p vrrp .*-j ACCEPT},
-  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable}
+  %r{-A INPUT -s 192.168.99.99(/32)? -p tcp -m tcp .*-j REJECT --reject-with icmp-port-unreachable},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1000:1100 .*-j ACCEPT},
+  %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234,5000:5100,5678 .*-j ACCEPT}
 ]
 
 expected_ipv6_rules = [
@@ -22,7 +24,9 @@ expected_ipv6_rules = [
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1235 .*-j REJECT --reject-with icmp6-port-unreachable},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1236 .*-j DROP},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p vrrp .*-j ACCEPT},
-  %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT}
+  %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1000:1100 .*-j ACCEPT},
+  %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234,5000:5100,5678 .*-j ACCEPT}
 ]
 
 describe command('iptables-save'), if: iptables? do

--- a/test/integration/default/serverspec/ufw_spec.rb
+++ b/test/integration/default/serverspec/ufw_spec.rb
@@ -8,7 +8,9 @@ expected_rules = [
   %r{ 1235/tcp + REJECT IN +Anywhere},
   %r{ 1236/tcp + DENY IN +Anywhere},
   %r{ Anywhere + REJECT IN +192.168.99.99/tcp},
-  %r{ 80/tcp + ALLOW IN +2001:db8::ff00:42:8329}
+  %r{ 80/tcp + ALLOW IN +2001:db8::ff00:42:8329},
+  %r{ 1000:1100/tcp + ALLOW IN +Anywhere},
+  %r{ 1234,5000:5100,5678/tcp + ALLOW IN +Anywhere}
 ]
 
 describe command('ufw status numbered'), if: debian? || ubuntu? do

--- a/test/integration/default/serverspec/windows_spec.rb
+++ b/test/integration/default/serverspec/windows_spec.rb
@@ -14,7 +14,9 @@ expected_rules = [
   %r{firewall add rule name="duplicate0" description="same comment" dir=in service=any protocol=tcp localip=any localport=5431,5432 interfacetype=any remoteip=any remoteport=any action=allow},
   %r{firewall add rule name="duplicate1" description="same comment" dir=in service=any protocol=tcp localip=any localport=1111 interfacetype=any remoteip=any remoteport=any action=allow},
   %r{firewall add rule name="duplicate1" description="same comment" dir=in service=any protocol=tcp localip=any localport=5431,5432 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="ipv6-source" description="ipv6-source" dir=in service=any protocol=tcp localip=any localport=80 interfacetype=any remoteip=2001:db8::ff00:42:8329 remoteport=any action=allow}
+  %r{firewall add rule name="ipv6-source" description="ipv6-source" dir=in service=any protocol=tcp localip=any localport=80 interfacetype=any remoteip=2001:db8::ff00:42:8329 remoteport=any action=allow},
+  %r{firewall add rule name="range" description="range" dir=in service=any protocol=tcp localip=any localport=1000-1100 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="array" description="array" dir=in service=any protocol=tcp localip=any localport=1234,5000-5100,5678 interfacetype=any remoteip=any remoteport=any action=allow}
 ]
 
 describe file("#{ENV['HOME']}/windows-chef.rules"), if: windows? do


### PR DESCRIPTION
Without this fix, a range would always end up in a format that is fine for Linux (`iptables`) systems, but breaks on Windows (Windows expects a range to be `10-20`, where Linux (`iptables`) expects it to be `10:20`).

Additionally things inside an Array where not checked and converted by this function which could also lead to issues when you (for example) had an Array with a range and an additional single port.