### PR TITLE
Add support for mobile shell firewall rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The default recipe creates a firewall resource with action install, and if `node
 # Attributes
 
 * `default['firewall']['allow_ssh'] = false`, set true to open port 22 for SSH when the default recipe runs
+* `default['firewall']['allow_mosh'] = false`, set to true to open UDP ports 60000 - 61000 for [Mosh][0] when the default recipe runs
 * `default['firewall']['allow_winrm'] = false`, set true to open port 5989 for WinRM when the default recipe runs
 
 * `default['firewall']['ubuntu_iptables'] = false`, set to true to use iptables on Ubuntu / Debian when using the default recipe
@@ -321,3 +322,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+[0]: https://mosh.mit.edu/

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['firewall']['allow_ssh'] = false
 default['firewall']['allow_winrm'] = false
+default['firewall']['allow_mosh'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,13 @@ firewall_rule 'allow world to winrm' do
   only_if { windows? && node['firewall']['allow_winrm'] }
 end
 
+firewall_rule 'allow world to mosh' do
+  protocol :udp
+  port 60000..61000
+  source '0.0.0.0/0'
+  only_if { linux? && node['firewall']['allow_mosh'] }
+end
+
 # allow established connections, ufw defaults to this but iptables does not
 firewall_rule 'established' do
   stateful [:related, :established]


### PR DESCRIPTION
This adds support for the firewall rules required for using the [mobile
shell](https://mosh.mit.edu) with the default recipe.