### PR TITLE
Make sure the firewall service can't restart without parsing all firewall rules

### DIFF
--- a/libraries/provider_firewall_firewalld.rb
+++ b/libraries/provider_firewall_firewalld.rb
@@ -56,6 +56,10 @@ class Chef
 
       # this populates the hash of rules from firewall_rule resources
       firewall_rules = run_context.resource_collection.select { |item| item.is_a?(Chef::Resource::FirewallRule) }
+      # Back out of restart if not all firewall rules have been added to the resource_collection.
+      # This can happen if at least one firewall_rule, but not all, have been created before the Chef run fails, due
+      # to the fact that delayed notifications still fire on a failed chef run.
+      next if firewall_rules.count { |item| !item.should_skip?(:create) } != node.run_state[:firewall_rules].count
       firewall_rules.each do |firewall_rule|
         next unless firewall_rule.action.include?(:create) && !firewall_rule.should_skip?(:create)
 

--- a/libraries/provider_firewall_iptables.rb
+++ b/libraries/provider_firewall_iptables.rb
@@ -68,6 +68,10 @@ class Chef
 
       # this populates the hash of rules from firewall_rule resources
       firewall_rules = run_context.resource_collection.select { |item| item.is_a?(Chef::Resource::FirewallRule) }
+      # Back out of restart if not all firewall rules have been added to the resource_collection.
+      # This can happen if at least one firewall_rule, but not all, have been created before the Chef run fails, due
+      # to the fact that delayed notifications still fire on a failed chef run.
+      next if firewall_rules.count { |item| !item.should_skip?(:create) } != node.run_state[:firewall_rules].count
       firewall_rules.each do |firewall_rule|
         next unless firewall_rule.action.include?(:create) && !firewall_rule.should_skip?(:create)
 

--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -68,6 +68,10 @@ class Chef
 
       # this populates the hash of rules from firewall_rule resources
       firewall_rules = run_context.resource_collection.select { |item| item.is_a?(Chef::Resource::FirewallRule) }
+      # Back out of restart if not all firewall rules have been added to the resource_collection.
+      # This can happen if at least one firewall_rule, but not all, have been created before the Chef run fails, due
+      # to the fact that delayed notifications still fire on a failed chef run.
+      next if firewall_rules.count { |item| !item.should_skip?(:create) } != node.run_state[:firewall_rules].count
       firewall_rules.each do |firewall_rule|
         next unless firewall_rule.action.include?(:create) && !firewall_rule.should_skip?(:create)
 

--- a/libraries/provider_firewall_rule.rb
+++ b/libraries/provider_firewall_rule.rb
@@ -21,6 +21,12 @@ class Chef
   class Provider::FirewallRuleGeneric < Chef::Provider::LWRPBase
     provides :firewall_rule
 
+    def initialize(*args)
+      super
+      node.run_state[:firewall_rules] ||= []
+      node.run_state[:firewall_rules] << args[0]
+    end
+
     action :create do
       return unless new_resource.notify_firewall
 

--- a/libraries/provider_firewall_ufw.rb
+++ b/libraries/provider_firewall_ufw.rb
@@ -63,6 +63,10 @@ class Chef
 
       # this populates the hash of rules from firewall_rule resources
       firewall_rules = run_context.resource_collection.select { |item| item.is_a?(Chef::Resource::FirewallRule) }
+      # Back out of restart if not all firewall rules have been added to the resource_collection.
+      # This can happen if at least one firewall_rule, but not all, have been created before the Chef run fails, due
+      # to the fact that delayed notifications still fire on a failed chef run.
+      next if firewall_rules.count { |item| !item.should_skip?(:create) } != node.run_state[:firewall_rules].count
       firewall_rules.each do |firewall_rule|
         next unless firewall_rule.action.include?(:create) && !firewall_rule.should_skip?(:create)
 

--- a/libraries/provider_firewall_windows.rb
+++ b/libraries/provider_firewall_windows.rb
@@ -44,6 +44,10 @@ class Chef
       new_resource.rules['windows'] = {} unless new_resource.rules['windows']
 
       firewall_rules = run_context.resource_collection.select { |item| item.is_a?(Chef::Resource::FirewallRule) }
+      # Back out of restart if not all firewall rules have been added to the resource_collection.
+      # This can happen if at least one firewall_rule, but not all, have been created before the Chef run fails, due
+      # to the fact that delayed notifications still fire on a failed chef run.
+      next if firewall_rules.count { |item| !item.should_skip?(:create) } != node.run_state[:firewall_rules].count
       firewall_rules.each do |firewall_rule|
         next unless firewall_rule.action.include?(:create) && !firewall_rule.should_skip?(:create)
 


### PR DESCRIPTION
Currently a situation can arise where a failed chef run causes the firewall service to rewrite its rule file with an incomplete rule set. The fix is to keep track of the firewall_rules in the compile phase, and verify that all the rules are represented in the resource collection before flushing the rule file and restarting the firewall service.