### PR TITLE
protocol guard incorrectly prevents "none" protocol type on UFW helper.

### DIFF
--- a/libraries/helpers_ufw.rb
+++ b/libraries/helpers_ufw.rb
@@ -46,7 +46,7 @@ module FirewallCookbook
         end
 
         # if we don't do this, ufw will fail as it does not support protocol numbers, so we'll only allow it to run if specifying icmp/tcp/udp protocol types
-        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp)$')
+        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp|none)$')
           msg = ''
           msg << "firewall_rule[#{new_resource.name}] was asked to "
           msg << "#{new_resource.command} a rule using protocol #{new_resource.protocol} "


### PR DESCRIPTION
The firewall cookbook in trying to prevent protocol numbers being supplied to the ```protocol``` property of ```firewall_rule``` when using the UFW provider also incorrectly prevents ```none``` as a valid value...which means you can't add an ALLOW ALL rule for an IP/CIDR.

This restores allowing the ```none``` value for ```protocol``` when using the UFW provider. 