### PR TITLE
Fix notify_firewall attribute crashing firewall_rule provider when set to false.

### DIFF
--- a/libraries/provider_firewall_rule.rb
+++ b/libraries/provider_firewall_rule.rb
@@ -22,13 +22,13 @@ class Chef
     provides :firewall_rule
 
     action :create do
-      return unless new_resource.notify_firewall
+      if new_resource.notify_firewall
+        firewall_resource = run_context.resource_collection.find(firewall: new_resource.firewall_name)
+        raise 'could not find a firewall resource' unless firewall_resource
 
-      firewall_resource = run_context.resource_collection.find(firewall: new_resource.firewall_name)
-      raise 'could not find a firewall resource' unless firewall_resource
-
-      new_resource.notifies(:restart, firewall_resource, :delayed)
-      new_resource.updated_by_last_action(true)
+        new_resource.notifies(:restart, firewall_resource, :delayed)
+        new_resource.updated_by_last_action(true)
+      end
     end
   end
 end


### PR DESCRIPTION
firewall_rule.notify_firewall if set to False, crashes the provider because the code tries to "return" early in a Ruby block which isn't allowed. Re-factored to use an if-statement to simply not run the code that would have been obviated with the early return.