### PR TITLE
allow ipv6/esp/ah protocol passthrough for ufw

### DIFF
--- a/libraries/helpers_ufw.rb
+++ b/libraries/helpers_ufw.rb
@@ -46,7 +46,7 @@ module FirewallCookbook
         end
 
         # if we don't do this, ufw will fail as it does not support protocol numbers, so we'll only allow it to run if specifying icmp/tcp/udp protocol types
-        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp|none)$')
+        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp|esp|ah|ipv6|none)$')
           msg = ''
           msg << "firewall_rule[#{new_resource.name}] was asked to "
           msg << "#{new_resource.command} a rule using protocol #{new_resource.protocol} "

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -15,7 +15,7 @@ class Chef
 
     attribute(:protocol, kind_of: [Integer, Symbol], default: :tcp,
                          callbacks: { 'must be either :tcp, :udp, :icmp, :\'ipv6-icmp\', :icmpv6, :none, or a valid IP protocol number' => lambda do |p|
-                           !!(p.to_s =~ /(udp|tcp|icmp|icmpv6|ipv6-icmp|none)/ || (p.to_s =~ /^\d+$/ && p.between?(0, 142)))
+                           !!(p.to_s =~ /(udp|tcp|icmp|icmpv6|ipv6-icmp|esp|ah|ipv6|none)/ || (p.to_s =~ /^\d+$/ && p.between?(0, 142)))
                          end })
     attribute(:direction, kind_of: Symbol, equal_to: [:in, :out, :pre, :post], default: :in)
     attribute(:logging, kind_of: Symbol, equal_to: [:connections, :packets])


### PR DESCRIPTION
### Description
allow ipv6/esp/ah protocols for ufw as per http://manpages.ubuntu.com/manpages/precise/man8/ufw.8.html
[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Obvious fix. (ref https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD)