### PR TITLE
Set status_command for iptables-persistent to "true".

### DIFF
--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -54,7 +54,7 @@ class Chef
 
         service 'iptables-persistent' do
           action [:enable, :start]
-          status_command "true" # iptables-persistent isn't a real service
+          status_command 'true' # iptables-persistent isn't a real service
         end
       end
     end

--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -52,6 +52,7 @@ class Chef
 
         service 'iptables-persistent' do
           action [:enable, :start]
+          status_command "true" # iptables-persistent isn't a real service
         end
       end
     end


### PR DESCRIPTION
### Description

Set status_command for iptables-persistent to "true".

    * iptables-persistent isn't a real service, so Chef
      can never find it in the process table and runs
      start on it every chef run, unnecessarily reloading
      the firewall rules when there is no change in the
      rule set.
    * Setting status_command to "true" causes Chef
      to never call start on iptables-persistent,
      which is fine because any rule changes trigger
      a restart on iptables-persistent.

### Issues Resolved

Set status_command for iptables-persistent to "true".

    * iptables-persistent isn't a real service, so Chef
      can never find it in the process table and runs
      start on it every chef run, unnecessarily reloading
      the firewall rules when there is no change in the
      rule set.
    * Setting status_command to "true" causes Chef
      to never call start on iptables-persistent,
      which is fine because any rule changes trigger
      a restart on iptables-persistent.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ X ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
