### PR TITLE
Adding rule_enabled windows helper method

### DIFF
--- a/libraries/helpers_windows.rb
+++ b/libraries/helpers_windows.rb
@@ -89,6 +89,13 @@ module FirewallCookbook
           cmd.stdout !~ /^No rules match the specified criteria/
         end
       end
+      
+      def rule_enabled?(name)
+        @enabled ||= begin
+          cmd = shell_out!("netsh advfirewall firewall show rule name=\"#{name}\" status=enabled", returns: [0, 1])
+          cmd.stdout !~ /^No rules match the specified criteria/
+        end
+      end
 
       def show_all_rules!
         cmd = shell_out!('netsh advfirewall firewall show rule name=all')


### PR DESCRIPTION
### Description

This allows a user to check if a firewall rule is enabled.

### Issues Resolved

None

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


