### PR TITLE
Add support for Ubuntu 16.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,9 @@ platforms:
   - name: ubuntu-14.04
     run_list:
       - recipe[apt::default]
+  - name: ubuntu-16.04
+    run_list:
+      - recipe[apt::default]
   - name: windows-2012r2
 
 suites:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ depends 'firewall', '< 2.0'
 * Windows Advanced Firewall - 2012 R2
 
 Tested on:
-* Ubuntu 12.04 & 14.04 with iptables, ufw
+* Ubuntu 12.04, 14.04, 16.04 with iptables, ufw
 * Debian 7.8, 8.1 with ufw
 * CentOS 5.11, 6.7 with iptables
 * CentOS 7.1 with firewalld

--- a/libraries/provider_firewall_iptables_ubuntu1404.rb
+++ b/libraries/provider_firewall_iptables_ubuntu1404.rb
@@ -18,12 +18,12 @@
 # limitations under the License.
 #
 class Chef
-  class Provider::FirewallIptablesUbuntu < Chef::Provider::LWRPBase
+  class Provider::FirewallIptablesUbuntu1404 < Chef::Provider::LWRPBase
     include FirewallCookbook::Helpers
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
-      node['platform_version'].to_f > 14.04 && node['firewall'] && node['firewall']['ubuntu_iptables']
+      node['platform_version'].to_f <= 14.04 && node['firewall'] && node['firewall']['ubuntu_iptables']
     end
 
     def whyrun_supported?
@@ -52,9 +52,9 @@ class Chef
           end
         end
 
-        service 'netfilter-persistent' do
+        service 'iptables-persistent' do
           action [:enable, :start]
-          status_command 'true' # netfilter-persistent isn't a real service
+          status_command 'true' # iptables-persistent isn't a real service
         end
       end
     end
@@ -116,7 +116,7 @@ class Chef
 
         # if the file was changed, restart iptables
         next unless iptables_file.updated_by_last_action?
-        service_affected = service 'netfilter-persistent' do
+        service_affected = service 'iptables-persistent' do
           action :nothing
         end
 
@@ -132,7 +132,7 @@ class Chef
       iptables_default_allow!(new_resource)
       new_resource.updated_by_last_action(true)
 
-      service 'netfilter-persistent' do
+      service 'iptables-persistent' do
         action [:disable, :stop]
       end
 

--- a/test/integration/helpers/serverspec/helpers.rb
+++ b/test/integration/helpers/serverspec/helpers.rb
@@ -26,3 +26,11 @@ end
 def windows?
   %w(windows).include?(os[:family])
 end
+
+def iptables_persistent?
+  ubuntu? && os[:release].to_f <= 14.04
+end
+
+def netfilter_persistent?
+  ubuntu? && os[:release].to_f > 14.04
+end

--- a/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
@@ -36,7 +36,11 @@ describe command('ip6tables-save'), if: ubuntu? do
   end
 end
 
-describe service('iptables-persistent'), if: ubuntu? do
+describe service('iptables-persistent'), if: iptables_persistent? do
+  it { should be_enabled }
+end
+
+describe service('netfilter-persistent'), if: netfilter_persistent? do
   it { should be_enabled }
 end
 


### PR DESCRIPTION
### Description

Add support for Ubuntu 16.04 LTS.

### Issues Resolved

Specifically it supports the change that `iptables-persistent` as a service was replaced by `netfilter-persistent`.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


From Ubuntu 16.04 the service `iptables-persistent` was replaced
by `netfilter-persistent` so we need to treat 14.04 and earlier
differently than 16.04 and later.