### PR TITLE
Add windows to metadata and add chef_version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,8 +14,10 @@ supports 'oracle'
 supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
+supports 'windows'
 
 depends 'chef-sugar'
 
-source_url 'https://github.com/chef-cookbooks/firewall' if respond_to?(:source_url)
-issues_url 'https://github.com/chef-cookbooks/firewall/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/chef-cookbooks/firewall'
+issues_url 'https://github.com/chef-cookbooks/firewall/issues'
+chef_version '>= 12.4' if respond_to?(:chef_version)


### PR DESCRIPTION
Windows is in the readme, but not in the metadata so it won't show up in Supermarket. This fixes that and also adds chef_version, which we'll surface in Supermarket sometime in the near future.