### PR TITLE
Adds ability to pass package options through to firewall package install

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@
 [List any existing issues this PR resolves]
 
 ### Check List
-- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
+
+- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
 - [ ] New functionality includes testing.
 - [ ] New functionality has been documented in the README if applicable
-- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
-
+- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,9 @@ platforms:
   - name: ubuntu-14.04
     run_list:
       - recipe[apt::default]
+  - name: ubuntu-16.04
+    run_list:
+      - recipe[apt::default]
   - name: windows-2012r2
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,8 @@ platforms:
     run_list:
       - recipe[apt::default]
   - name: windows-2012r2
+    driver_config:
+      box: windows2012r2
 
 suites:
   - name: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ firewall Cookbook CHANGELOG
 =======================
 This file is used to list changes made in each version of the firewall cookbook.
 
+v2.5.3 (2016-10-26)
+-------------------
+* Don't show firewall resource as updated (#133)
+* Add :off as a valid logging level (#129)
+* Add support for Ubuntu 16.04 (#149)
+
 v2.5.2 (2016-06-02)
 -------------------
 * Don't issue commands when firewalld isn't active (#140)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The default recipe creates a firewall resource with action install, and if `node
 
 - `disabled` (default to `false`): If set to true, all actions will no-op on this resource. This is a way to prevent included cookbooks from configuring a firewall.
 - `ipv6_enabled` (default to `true`): If set to false, firewall will not perform any ipv6 related work. Currently only supported in iptables.
-- `log_level`: UFW only. Level of verbosity the firewall should log at. valid values are: :low, :medium, :high, :full. default is :low.
+- `log_level`: UFW only. Level of verbosity the firewall should log at. valid values are: :low, :medium, :high, :full, :off. default is :low.
 - `rules`: This is used internally for firewall_rule resources to append their rules. You should NOT touch this value unless you plan to supply an entire firewall ruleset at once, and skip using firewall_rule resources.
 - `disabled_zone` (firewalld only): The zone to set on firewalld when the firewall should be disabled. Can be any string in symbol form, e.g. :public, :drop, etc. Defaults to `:public.`
 - `enabled_zone` (firewalld only): The zone to set on firewalld when the firewall should be enabled. Can be any string in symbol form, e.g. :public, :drop, etc. Defaults to `:drop.`

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The default recipe creates a firewall resource with action install, and if `node
 * `default['firewall']['ufw']['defaults']` hash for template `/etc/default/ufw`
 * `default['firewall']['iptables']['defaults']` hash for default policies for 'filter' table's chains`
 
+* `default['firewall']['windows']['defaults']` hash to define inbound / outbound firewall policy on Windows platform
+
 * `default['firewall']['allow_established'] = true`, set to false if you don't want a related/established default rule on iptables
 * `default['firewall']['ipv6_enabled'] = true`, set to false if you don't want IPv6 related/established default rule on iptables (this enables ICMPv6, which is required for much of IPv6 communication)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ depends 'firewall', '< 2.0'
 * Windows Advanced Firewall - 2012 R2
 
 Tested on:
-* Ubuntu 12.04 & 14.04 with iptables, ufw
+* Ubuntu 12.04, 14.04, 16.04 with iptables, ufw
 * Debian 7.8, 8.1 with ufw
 * CentOS 5.11, 6.7 with iptables
 * CentOS 7.1 with firewalld

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The default recipe creates a firewall resource with action install, and if `node
 - `rules`: This is used internally for firewall_rule resources to append their rules. You should NOT touch this value unless you plan to supply an entire firewall ruleset at once, and skip using firewall_rule resources.
 - `disabled_zone` (firewalld only): The zone to set on firewalld when the firewall should be disabled. Can be any string in symbol form, e.g. :public, :drop, etc. Defaults to `:public.`
 - `enabled_zone` (firewalld only): The zone to set on firewalld when the firewall should be enabled. Can be any string in symbol form, e.g. :public, :drop, etc. Defaults to `:drop.`
+- `package_options`: Used to pass options to the package install of firewall
 
 #### Examples
 

--- a/attributes/windows.rb
+++ b/attributes/windows.rb
@@ -1,0 +1,8 @@
+# Windows platform defult settings: block undefined inbould traffic, allow all outgoing traffic
+
+default['firewall']['windows']['defaults'] = {
+  policy: {
+    input: 'blockinbound',
+    output: 'allowoutbound'
+  }
+}

--- a/libraries/helpers_windows.rb
+++ b/libraries/helpers_windows.rb
@@ -60,7 +60,7 @@ module FirewallCookbook
         parameters['dir'] = new_resource.direction
 
         new_resource.program && parameters['program'] = new_resource.program
-        parameters['service'] = new_resource.service ? new_resource.service : 'any'
+        new_resource.service && parameters['service'] = new_resource.service
         parameters['protocol'] = new_resource.protocol
 
         if new_resource.direction.to_sym == :out

--- a/libraries/provider_firewall_firewalld.rb
+++ b/libraries/provider_firewall_firewalld.rb
@@ -33,6 +33,7 @@ class Chef
       converge_by('install firewalld, create template for /etc/sysconfig') do
         package 'firewalld' do
           action :install
+          options new_resource.package_options
         end
 
         service 'firewalld' do

--- a/libraries/provider_firewall_iptables_ubuntu1404.rb
+++ b/libraries/provider_firewall_iptables_ubuntu1404.rb
@@ -18,12 +18,12 @@
 # limitations under the License.
 #
 class Chef
-  class Provider::FirewallIptablesUbuntu < Chef::Provider::LWRPBase
+  class Provider::FirewallIptablesUbuntu1404 < Chef::Provider::LWRPBase
     include FirewallCookbook::Helpers
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
-      node['platform_version'].to_f > 14.04 && node['firewall'] && node['firewall']['ubuntu_iptables']
+      node['platform_version'].to_f <= 14.04 && node['firewall'] && node['firewall']['ubuntu_iptables']
     end
 
     def whyrun_supported?
@@ -52,9 +52,9 @@ class Chef
           end
         end
 
-        service 'netfilter-persistent' do
+        service 'iptables-persistent' do
           action [:enable, :start]
-          status_command 'true' # netfilter-persistent isn't a real service
+          status_command 'true' # iptables-persistent isn't a real service
         end
       end
     end
@@ -116,7 +116,7 @@ class Chef
 
         # if the file was changed, restart iptables
         next unless iptables_file.updated_by_last_action?
-        service_affected = service 'netfilter-persistent' do
+        service_affected = service 'iptables-persistent' do
           action :nothing
         end
 
@@ -132,7 +132,7 @@ class Chef
       iptables_default_allow!(new_resource)
       new_resource.updated_by_last_action(true)
 
-      service 'netfilter-persistent' do
+      service 'iptables-persistent' do
         action [:disable, :stop]
       end
 

--- a/libraries/provider_firewall_windows.rb
+++ b/libraries/provider_firewall_windows.rb
@@ -30,7 +30,7 @@ class Chef
       next if disabled?(new_resource)
 
       svc = service 'MpsSvc' do
-          action :nothing
+        action :nothing
       end
 
       [:enable, :start].each do |act|

--- a/libraries/provider_firewall_windows.rb
+++ b/libraries/provider_firewall_windows.rb
@@ -60,6 +60,13 @@ class Chef
         end
       end
 
+      input_policy = node['firewall']['windows']['defaults']['policy']['input']
+      output_policy = node['firewall']['windows']['defaults']['policy']['output']
+      unless new_resource.rules['windows'].key?("set currentprofile firewallpolicy #{input_policy},#{output_policy}")
+        # Make this the possible last rule in the list
+        new_resource.rules['windows']["set currentprofile firewallpolicy #{input_policy},#{output_policy}"] = 99999
+      end
+
       # ensure a file resource exists with the current rules
       begin
         windows_file = run_context.resource_collection.find(file: windows_rules_filename)

--- a/libraries/resource_firewall.rb
+++ b/libraries/resource_firewall.rb
@@ -10,7 +10,7 @@ class Chef
     attribute(:disabled, kind_of: [TrueClass, FalseClass], default: false)
     attribute(:enabled, kind_of: [TrueClass, FalseClass], default: true)
 
-    attribute(:log_level, kind_of: Symbol, equal_to: [:low, :medium, :high, :full], default: :low)
+    attribute(:log_level, kind_of: Symbol, equal_to: [:low, :medium, :high, :full, :off], default: :low)
     attribute(:rules, kind_of: Hash)
 
     # for firewalld, specify the zone when firewall is disable and enabled

--- a/libraries/resource_firewall.rb
+++ b/libraries/resource_firewall.rb
@@ -19,5 +19,8 @@ class Chef
 
     # for firewall implementations where ipv6 can be skipped (currently iptables-specific)
     attribute(:ipv6_enabled, kind_of: [TrueClass, FalseClass], default: true)
+
+    # allow override of package options for firewalld package
+    attribute(:package_options, kind_of: String, default: nil)
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Provides a set of primitives for managing firewalls and associated rules.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.5.2'
+version '2.5.3'
 
 supports 'amazon'
 supports 'centos'

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -105,3 +105,12 @@ firewall_rule 'RPC Port Range In' do
   # see https://github.com/chef-cookbooks/firewall/pull/111#issuecomment-163520156
   not_if { rhel? && node['platform_version'].to_f < 6.0 }
 end
+
+firewall_rule 'HTTP HTTPS' do
+  port [80, 443]
+  protocol :tcp
+  direction :out
+  command :allow
+end
+
+include_recipe 'firewall-test::windows' if windows?

--- a/test/fixtures/cookbooks/firewall-test/recipes/windows.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/windows.rb
@@ -1,0 +1,7 @@
+
+node.override['firewall']['windows']['defaults'] = {
+  policy: {
+    input: 'blockinbound',
+    output: 'blockoutbound'
+  }
+}

--- a/test/integration/default/serverspec/windows_spec.rb
+++ b/test/integration/default/serverspec/windows_spec.rb
@@ -2,25 +2,29 @@
 require 'spec_helper'
 
 expected_rules = [
-  %r{firewall add rule name="prepend" description="prepend" dir=in service=any protocol=tcp localip=any localport=7788 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="block-192.168.99.99" description="block-192.168.99.99" dir=in service=any protocol=tcp localip=any localport=any interfacetype=any remoteip=192.168.99.99 remoteport=any action=block},
-  %r{firewall add rule name="allow world to winrm" description="allow world to winrm" dir=in service=any protocol=tcp localip=any localport=5989 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="ssh22" description="ssh22" dir=in service=any protocol=tcp localip=any localport=22 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="ssh2222" description="ssh2222" dir=in service=any protocol=tcp localip=any localport=2200,2222 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="temp1" description="temp1" dir=in service=any protocol=tcp localip=any localport=1234 interfacetype=any remoteip=any remoteport=any action=block},
-  %r{firewall add rule name="temp2" description="temp2" dir=in service=any protocol=tcp localip=any localport=1235 interfacetype=any remoteip=any remoteport=any action=block},
-  %r{firewall add rule name="addremove2" description="addremove2" dir=in service=any protocol=tcp localip=any localport=1236 interfacetype=any remoteip=any remoteport=any action=block},
-  %r{firewall add rule name="duplicate0" description="same comment" dir=in service=any protocol=tcp localip=any localport=1111 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="duplicate0" description="same comment" dir=in service=any protocol=tcp localip=any localport=5431,5432 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="duplicate1" description="same comment" dir=in service=any protocol=tcp localip=any localport=1111 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="duplicate1" description="same comment" dir=in service=any protocol=tcp localip=any localport=5431,5432 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="ipv6-source" description="ipv6-source" dir=in service=any protocol=tcp localip=any localport=80 interfacetype=any remoteip=2001:db8::ff00:42:8329 remoteport=any action=allow},
-  %r{firewall add rule name="range" description="range" dir=in service=any protocol=tcp localip=any localport=1000-1100 interfacetype=any remoteip=any remoteport=any action=allow},
-  %r{firewall add rule name="array" description="array" dir=in service=any protocol=tcp localip=any localport=1234,5000-5100,5678 interfacetype=any remoteip=any remoteport=any action=allow}
+  %r{firewall add rule name="prepend" description="prepend" dir=in protocol=tcp localip=any localport=7788 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="block-192.168.99.99" description="block-192.168.99.99" dir=in protocol=tcp localip=any localport=any interfacetype=any remoteip=192.168.99.99 remoteport=any action=block},
+  %r{firewall add rule name="allow world to winrm" description="allow world to winrm" dir=in protocol=tcp localip=any localport=5989 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="ssh22" description="ssh22" dir=in protocol=tcp localip=any localport=22 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="ssh2222" description="ssh2222" dir=in protocol=tcp localip=any localport=2200,2222 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="temp1" description="temp1" dir=in protocol=tcp localip=any localport=1234 interfacetype=any remoteip=any remoteport=any action=block},
+  %r{firewall add rule name="temp2" description="temp2" dir=in protocol=tcp localip=any localport=1235 interfacetype=any remoteip=any remoteport=any action=block},
+  %r{firewall add rule name="addremove2" description="addremove2" dir=in protocol=tcp localip=any localport=1236 interfacetype=any remoteip=any remoteport=any action=block},
+  %r{firewall add rule name="duplicate0" description="same comment" dir=in protocol=tcp localip=any localport=1111 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="duplicate0" description="same comment" dir=in protocol=tcp localip=any localport=5431,5432 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="duplicate1" description="same comment" dir=in protocol=tcp localip=any localport=1111 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="duplicate1" description="same comment" dir=in protocol=tcp localip=any localport=5431,5432 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="ipv6-source" description="ipv6-source" dir=in protocol=tcp localip=any localport=80 interfacetype=any remoteip=2001:db8::ff00:42:8329 remoteport=any action=allow},
+  %r{firewall add rule name="range" description="range" dir=in protocol=tcp localip=any localport=1000-1100 interfacetype=any remoteip=any remoteport=any action=allow},
+  %r{firewall add rule name="array" description="array" dir=in protocol=tcp localip=any localport=1234,5000-5100,5678 interfacetype=any remoteip=any remoteport=any action=allow}
 ]
 
 describe file("#{ENV['HOME']}/windows-chef.rules"), if: windows? do
   expected_rules.each do |r|
     its(:content) { should match(r) }
   end
+end
+
+describe command('netsh advfirewall show currentprofile firewallpolicy | findstr "Firewall Policy"'), if: windows? do
+  its(:stdout) { should match('BlockInbound,BlockOutbound') }
 end

--- a/test/integration/helpers/serverspec/helpers.rb
+++ b/test/integration/helpers/serverspec/helpers.rb
@@ -26,3 +26,11 @@ end
 def windows?
   %w(windows).include?(os[:family])
 end
+
+def iptables_persistent?
+  ubuntu? && os[:release].to_f <= 14.04
+end
+
+def netfilter_persistent?
+  ubuntu? && os[:release].to_f > 14.04
+end

--- a/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
@@ -36,7 +36,11 @@ describe command('ip6tables-save'), if: ubuntu? do
   end
 end
 
-describe service('iptables-persistent'), if: ubuntu? do
+describe service('iptables-persistent'), if: iptables_persistent? do
+  it { should be_enabled }
+end
+
+describe service('netfilter-persistent'), if: netfilter_persistent? do
   it { should be_enabled }
 end
 


### PR DESCRIPTION
### Description

This change allows package_options to be passed through to the package install for firewall
### Issues Resolved

Our environment requires package_options to avoid hanging during the install. This modification allowed that to happen.
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
