### PR TITLE
Allow loopback and icmp, when enabled

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,9 @@ provisioner:
     firewall:
       allow_ssh: true
       allow_winrm: true
+      allow_mosh: true
+      allow_loopback: true
+      allow_icmp: true
       firewalld:
         permanent: true
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,15 @@ keys must be unique but we need multiple commit lines.
 # Recipes
 
 ### default
-The default recipe creates a firewall resource with action install, and if `node['firewall']['allow_ssh']`, opens port 22 from the world.
+The default recipe creates a firewall resource with action install.
 
 # Attributes
 
 * `default['firewall']['allow_ssh'] = false`, set true to open port 22 for SSH when the default recipe runs
 * `default['firewall']['allow_mosh'] = false`, set to true to open UDP ports 60000 - 61000 for [Mosh][0] when the default recipe runs
 * `default['firewall']['allow_winrm'] = false`, set true to open port 5989 for WinRM when the default recipe runs
+* `default['firewall']['allow_loopback'] = false`, set to true to allow all traffic on the loopback interface
+* `default['firewall']['allow_icmp'] = false`, set true to allow icmp protocol on supported OSes (note: ufw and windows implementations don't support this)
 
 * `default['firewall']['ubuntu_iptables'] = false`, set to true to use iptables on Ubuntu / Debian when using the default recipe
 * `default['firewall']['redhat7_iptables'] = false`, set to true to use iptables on Red Hat / CentOS 7 when using the default recipe

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
 default['firewall']['allow_ssh'] = false
 default['firewall']['allow_winrm'] = false
 default['firewall']['allow_mosh'] = false
+default['firewall']['allow_loopback'] = false
+default['firewall']['allow_icmp'] = false

--- a/libraries/helpers_ufw.rb
+++ b/libraries/helpers_ufw.rb
@@ -46,7 +46,7 @@ module FirewallCookbook
         end
 
         # if we don't do this, ufw will fail as it does not support protocol numbers, so we'll only allow it to run if specifying icmp/tcp/udp protocol types
-        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|icmp|esp|ah|ipv6|none)$')
+        if new_resource.protocol && !new_resource.protocol.to_s.downcase.match('^(tcp|udp|esp|ah|ipv6|none)$')
           msg = ''
           msg << "firewall_rule[#{new_resource.name}] was asked to "
           msg << "#{new_resource.command} a rule using protocol #{new_resource.protocol} "

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,21 @@ end
 # create a variable to use as a condition on some rules that follow
 iptables_firewall = rhel? || node['firewall']['ubuntu_iptables']
 
+firewall_rule 'allow loopback' do
+  interface 'lo'
+  protocol :none
+  command :allow
+  only_if { linux? && node['firewall']['allow_loopback'] }
+end
+
+firewall_rule 'allow icmp' do
+  protocol :icmp
+  command :allow
+  # debian ufw doesn't allow 'icmp' protocol, but does open
+  # icmp by default, so we skip it in default recipe
+  only_if { linux? && !debian? && node['firewall']['allow_icmp'] }
+end
+
 firewall_rule 'allow world to ssh' do
   port 22
   source '0.0.0.0/0'

--- a/test/integration/default/serverspec/firewalld_spec.rb
+++ b/test/integration/default/serverspec/firewalld_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 
 expected_rules = [
+  %r{ipv4 filter INPUT 50 -i lo -m comment --comment 'allow loopback' -j ACCEPT},
+  %r{ipv4 filter INPUT 50 -p icmp -m comment --comment 'allow icmp' -j ACCEPT},
   %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 22 -m comment --comment 'allow world to ssh' -j ACCEPT},
   %r{ipv4 filter INPUT 50 -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
   %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 22 -m comment --comment ssh22 -j ACCEPT},
@@ -17,6 +19,8 @@ expected_rules = [
   %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1000:1100 -m comment --comment range -j ACCEPT},
   %r{ipv4 filter INPUT 50 -p tcp -m tcp -m multiport --dports 1234,5000:5100,5678 -m comment --comment array -j ACCEPT},
   # ipv6
+  %r{ipv6 filter INPUT 50 -i lo -m comment --comment 'allow loopback' -j ACCEPT},
+  %r{ipv6 filter INPUT 50 -p icmp -m comment --comment 'allow icmp' -j ACCEPT},
   %r{ipv6 filter INPUT 50 -m state --state RELATED,ESTABLISHED -m comment --comment established -j ACCEPT},
   %r{ipv6 filter INPUT 50 -p ipv6-icmp -m comment --comment ipv6_icmp -j ACCEPT},
   %r{ipv6 filter INPUT 50 -p tcp -m tcp -m multiport --dports 22 -m comment --comment ssh22 -j ACCEPT},

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 
 expected_rules = [
   # we included the .*-j so that we don't bother testing comments
+  %r{-A INPUT -i lo .*-j ACCEPT},
+  %r{-A INPUT -p icmp .*-j ACCEPT},
   %r{-A INPUT -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
@@ -14,6 +16,8 @@ expected_rules = [
 ]
 
 expected_ipv6_rules = [
+  %r{-A INPUT -i lo .*-j ACCEPT},
+  %r{-A INPUT -p icmp .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT.* -p ipv6-icmp .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},

--- a/test/integration/iptables/serverspec/iptables_redhat_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_redhat_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 
 expected_rules = [
   # we included the .*-j so that we don't bother testing comments
+  %r{-A INPUT -i lo .*-j ACCEPT},
+  %r{-A INPUT -p icmp .*-j ACCEPT},
   %r{-A INPUT -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
@@ -14,6 +16,8 @@ expected_rules = [
 ]
 
 expected_ipv6_rules = [
+  %r{-A INPUT -i lo .*-j ACCEPT},
+  %r{-A INPUT -p icmp .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -m state --state RELATED,ESTABLISHED .*-j ACCEPT},
   %r{-A INPUT.* -p ipv6-icmp .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},

--- a/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 expected_rules = [
   # we included the .*-j so that we don't bother testing comments
+  %r{-A INPUT -i lo .*-j ACCEPT},
+  %r{-A INPUT -p icmp .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
   %r{-A INPUT -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},
@@ -12,6 +14,8 @@ expected_rules = [
 
 expected_ipv6_rules = [
   %r{-A INPUT -p ipv6-icmp .* -j ACCEPT},
+  %r{-A INPUT -i lo .*-j ACCEPT},
+  %r{-A INPUT -p icmp .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 22 .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 2200,2222 .*-j ACCEPT},
   %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234 .*-j DROP},


### PR DESCRIPTION
### Description

We are adding settings, that default to false, for opening up loopbck and icmp in the default recipe.

Notes:
- ufw doesn't allow proto `icmp`, so we skip it on debian? based distros
- windows has issues in our implementation, so don't open stuff there (see #156)
- update tests to check for the new rules

Fixes #158 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
