### PR TITLE
Add disable_firewall recipe for use with clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ keys must be unique but we need multiple commit lines.
 ### default
 The default recipe creates a firewall resource with action install.
 
+### disable_firewall
+Used to disable platform specific firewall. Many clouds have their own firewall configured outside of the OS instance such as AWS Security Groups.
+
 # Attributes
 
 * `default['firewall']['allow_ssh'] = false`, set true to open port 22 for SSH when the default recipe runs

--- a/recipes/disable_firewall.rb
+++ b/recipes/disable_firewall.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook:: firewall
+# Recipe:: disable_firewall
+#
+# Copyright:: 2011-2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Disable platform default firewall
+firewall 'default' do
+  action :disable
+end


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <corey.hemminger@nativex.com>

### Description

Adds recipe to disable OS firewall. This is best practice in many clouds like AWS that use their own firewall through Security Groups attached to an instance.

### Issues Resolved

Feature add.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
