### PR TITLE
Incorrect file checking

### DIFF
--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -43,7 +43,7 @@ class Chef
       rule_files = %w(rules.v4)
       rule_files << 'rules.v6' if ipv6_enabled?(new_resource)
       rule_files.each do |svc|
-        next unless ::File.exist?("/etc/iptables/#{svc}")
+        next if ::File.exist?("/etc/iptables/#{svc}")
 
         # must create empty file for service to start
         f = lookup_or_create_rulesfile(svc)

--- a/libraries/provider_firewall_iptables_ubuntu1404.rb
+++ b/libraries/provider_firewall_iptables_ubuntu1404.rb
@@ -43,7 +43,7 @@ class Chef
       rule_files = %w(rules.v4)
       rule_files << 'rules.v6' if ipv6_enabled?(new_resource)
       rule_files.each do |svc|
-        next unless ::File.exist?("/etc/iptables/#{svc}")
+        next if ::File.exist?("/etc/iptables/#{svc}")
 
         # must create empty file for service to start
         f = lookup_or_create_rulesfile(svc)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Provides a set of primitives for managing firewalls and associated rules.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.6.1'
+version '2.6.2'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
### Description

On the Ubuntu when `ubuntu_iptables` is being enabled, firewall rules get created twice. First, it creates a file with default rules, it restarts the firewall and then it creates a file with rules defined with `firewall_rule` resource. This actually, causes a security bug, I guess. The firewall gets opened for the short amount of time (this time varies on the chef run) but when `allow_established` (the default is `true`) is being employed it makes a possibility to create a connection behind the firewall and this connection won't be killed when proper rules are in place.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
