### PR TITLE
Incorrect file checking

### DIFF
--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -43,7 +43,7 @@ class Chef
       rule_files = %w(rules.v4)
       rule_files << 'rules.v6' if ipv6_enabled?(new_resource)
       rule_files.each do |svc|
-        next unless ::File.exist?("/etc/iptables/#{svc}")
+        next if ::File.exist?("/etc/iptables/#{svc}")
 
         # must create empty file for service to start
         f = lookup_or_create_rulesfile(svc)

--- a/libraries/provider_firewall_iptables_ubuntu1404.rb
+++ b/libraries/provider_firewall_iptables_ubuntu1404.rb
@@ -43,7 +43,7 @@ class Chef
       rule_files = %w(rules.v4)
       rule_files << 'rules.v6' if ipv6_enabled?(new_resource)
       rule_files.each do |svc|
-        next unless ::File.exist?("/etc/iptables/#{svc}")
+        next if ::File.exist?("/etc/iptables/#{svc}")
 
         # must create empty file for service to start
         f = lookup_or_create_rulesfile(svc)


### PR DESCRIPTION
Rebased from #170. Thanks for the contribution @mwolny!

    Seems like file checking on Ubuntu is incorrect. Due to this bug,
    firewall rules get created twice at least. This basically opens up a
    firewall and closes it down. Actually it makes a security hole when
    allow_established is being employed.

Signed-off-by: Marcin Wolny <marcin@wutanic.com>

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
