### PR TITLE
Update Kitchen config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,7 +16,7 @@ provisioner:
 
 platforms:
   - name: centos-6.9
-  - name: centos-7.2
+  - name: centos-7.3
   - name: debian-7.11
     run_list:
       - recipe[apt]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 13.0.118
+  require_chef_omnibus: 13
   attributes:
     firewall:
       allow_ssh: true


### PR DESCRIPTION
This PR updates test kitchen to use the latest stable version of Chef and adds CentOS version 7.3 as box.

