### PR TITLE
Fix security warning in rubocop

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,12 +15,12 @@ provisioner:
         permanent: true
 
 platforms:
-  - name: centos-6.9
-  - name: centos-7.3
-  - name: debian-7.11
+  - name: centos-6
+  - name: centos-7
+  - name: debian-7
     run_list:
       - recipe[apt]
-  - name: debian-8.7
+  - name: debian-8
     run_list:
       - recipe[apt]
   - name: ubuntu-14.04
@@ -39,10 +39,10 @@ suites:
 
   - name: iptables
     excludes:
-      - centos-5.11
-      - centos-6.9
-      - debian-7.11
-      - debian-8.7
+      - centos-5
+      - centos-6
+      - debian-7
+      - debian-8
       - windows-2012r2
     run_list:
       - recipe[firewall-test::default]

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 group :lint do
   gem 'cookstyle', '~> 1.3'
   gem 'foodcritic', '~> 10.3'
-  gem 'rubocop', '~> 0.47'
 end
 
 group :unit do
@@ -39,7 +38,7 @@ group :development do
   gem 'guard-kitchen'
   gem 'guard-rspec'
   gem 'guard-rubocop'
-  gem 'rake', '~> 11.0'
+  gem 'rake', '~> 12.0'
   gem 'rb-fsevent'
   gem 'ruby_gntp'
   gem 'stove'

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
  - iptables' `-S` not supported in libraries/provider_firewall_iptables.rb
  - save action might not make sense for firewalls
- - chef 11.x support / compat

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-at_exit { ChefSpec::Coverage.report! }
+RSpec.configure do |config|
+  config.color = true               # Use color in STDOUT
+  config.formatter = :documentation # Use the specified formatter
+  config.log_level = :error         # Avoid deprecation notice SPAM
+end


### PR DESCRIPTION
Use cookstyle directly

Signed-off-by: Tim Smith <tsmith@chef.io>