### PR TITLE
Allow Optional Comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ end
 
 - `description` (_default: same as rule name_): Used to provide a comment that will be included when adding the firewall rule.
 
+- `include_comment` (_default: true_): Used to optionally exclude the comment in the rule.
+
 - `position` (_default: 50_): **relative** position to insert rule at. Position may be any integer between 0 < n < 100 (exclusive), and more than one rule may specify the same position.
 
 - `command`: What action to take on a particular packet

--- a/libraries/helpers_firewalld.rb
+++ b/libraries/helpers_firewalld.rb
@@ -105,7 +105,7 @@ module FirewallCookbook
         firewall_rule << "-m multiport --dports #{port_to_s(dport_calc(new_resource))} " if dport_calc(new_resource)
 
         firewall_rule << "-m state --state #{new_resource.stateful.is_a?(Array) ? new_resource.stateful.join(',').upcase : new_resource.stateful.to_s.upcase} " if new_resource.stateful
-        firewall_rule << "-m comment --comment '#{new_resource.description}' "
+        firewall_rule << "-m comment --comment '#{new_resource.description}' " if new_resource.include_comment
         firewall_rule << "-j #{TARGET[type]} "
         firewall_rule << "--to-ports #{new_resource.redirect_port} " if type == :redirect
         firewall_rule.strip!

--- a/libraries/helpers_iptables.rb
+++ b/libraries/helpers_iptables.rb
@@ -39,7 +39,7 @@ module FirewallCookbook
         firewall_rule << "-m state --state #{rule_resource.stateful.is_a?(Array) ? rule_resource.stateful.join(',').upcase : rule_resource.stateful.upcase} " if rule_resource.stateful
         # the comments extension is not available for ip6tables on rhel/centos 5
         unless el5 && ipv6
-          firewall_rule << "-m comment --comment \"#{rule_resource.description}\" "
+          firewall_rule << "-m comment --comment \"#{rule_resource.description}\" " if rule_resource.include_comment
         end
 
         firewall_rule << "-j #{TARGET[rule_resource.command.to_sym]} "

--- a/libraries/resource_firewall_rule.rb
+++ b/libraries/resource_firewall_rule.rb
@@ -33,6 +33,7 @@ class Chef
     attribute(:stateful, kind_of: [Symbol, Array])
     attribute(:redirect_port, kind_of: Integer)
     attribute(:description, kind_of: String, name_attribute: true)
+    attribute(:include_comment, kind_of: [TrueClass, FalseClass], default: true)
 
     # only used for firewalld
     attribute(:permanent, kind_of: [TrueClass, FalseClass], default: false)

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -113,4 +113,13 @@ firewall_rule 'HTTP HTTPS' do
   command :allow
 end
 
+firewall_rule 'port2433' do
+  description 'This should not be included'
+  include_comment false
+  source    '127.0.0.0/8'
+  port      2433
+  direction :in
+  command   :allow
+end
+
 include_recipe 'firewall-test::windows' if windows?

--- a/test/integration/iptables/serverspec/iptables_redhat_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_redhat_spec.rb
@@ -42,6 +42,10 @@ describe command('iptables-save'), if: redhat? do
 
   duplicate_rule2 = '-A INPUT -p tcp -m tcp -m multiport --dports 5431,5432 -m comment --comment "same comment" -j ACCEPT'
   its(:stdout) { should count_occurences(duplicate_rule2, 1) }
+
+  # test that a comment was not included on purpose
+  its(:stdout) { should match('A INPUT -s 127.0.0.0/8 -p tcp -m tcp -m multiport --dports 2433 -j ACCEPT') }
+  its(:stdout) { should_not match('A INPUT -s 127.0.0.0/8 -p tcp -m tcp -m multiport --dports 2433 -j ACCEPT -m comment --comment "This should not be included"') }
 end
 
 describe command('ip6tables-save'), if: redhat? do


### PR DESCRIPTION
### Description

Allow iptable rule comments to be excluded with a flag. Sometimes it might be necessary to not have a comment for a given rule. 

### Issues Resolved

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
