### PR TITLE
remove explicit include of recipe chef_sugar::default

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+chef_sugar_cookbook_version = Gem::Version.new(run_context.cookbook_collection['chef-sugar'].metadata.version)
+
+include_recipe 'chef-sugar' if chef_sugar_cookbook_version < Gem::Version.new('4.0.0')
+
 firewall 'default' do
   ipv6_enabled node['firewall']['ipv6_enabled']
   action :install

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe 'chef-sugar'
-
 firewall 'default' do
   ipv6_enabled node['firewall']['ipv6_enabled']
   action :install


### PR DESCRIPTION


### Description

This PR removes the outdated `include 'chef_sugar'` line from `recipe[firewal_default]`.

Since v4.0.0. of the chef_sugar it is [no longer required to include this recipe explicitly](https://github.com/sethvargo/chef-sugar/blob/013352253e75fe6333c8690812fbfd1e0d2bc30b/recipes/default.rb#L20) and doing so generates warnings as described below.

### Issues Resolved

- the following warning is currently logged each time someone converges with a recipe which includes or depends on `recipe[firewall:default]`:
    ````
    WARN: chef-sugar::default no longer needs to be included in your runlist.
          Instead simply depend on the chef-sugar cookbook and the gem will
          be intalled and loaded automatically.
    ````
    this can happen once for each chefspec which uses the `chef_run` pattern creating a lot of repetative noise in rspec output.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing (no new functionality).
- [x] New functionality has been documented in the README if applicable (no new functionality)
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
