### PR TITLE
tacit iptables support for Debian 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Policyfile.lock.json
 .vagrant/
 .vagrant.d/
 .kitchen/
+
+# mac
+.DS_Store

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,9 @@ platforms:
   - name: debian-8
     run_list:
       - recipe[apt]
+  - name: debian-9
+    run_list:
+      - recipe[apt]
   - name: ubuntu-14.04
     run_list:
       - recipe[apt::default]
@@ -33,6 +36,8 @@ platforms:
 
 suites:
   - name: default
+    excludes:
+      - debian-9
     run_list:
       - recipe[firewall::default]
       - recipe[firewall-test::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,7 +25,7 @@ platforms:
       - recipe[apt]
   - name: debian-9
     run_list:
-      - recipe[apt]
+      - recipe[apt::default]
   - name: ubuntu-14.04
     run_list:
       - recipe[apt::default]
@@ -36,8 +36,6 @@ platforms:
 
 suites:
   - name: default
-    excludes:
-      - debian-9
     run_list:
       - recipe[firewall::default]
       - recipe[firewall-test::default]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ depends 'firewall', '< 2.0'
 ```
 
 ### Supported firewalls and platforms
-* UFW - Ubuntu, Debian
+* UFW - Ubuntu, Debian (except 9)
 * IPTables - Red Hat & CentOS, Ubuntu
 * FirewallD - Red Hat & CentOS >= 7.0 (IPv4 only support, [needs contributions/testing](https://github.com/chef-cookbooks/firewall/issues/86))
 * Windows Advanced Firewall - 2012 R2
@@ -24,6 +24,7 @@ depends 'firewall', '< 2.0'
 Tested on:
 * Ubuntu 14.04, 16.04 with iptables, ufw
 * Debian 7, 8 with ufw
+* Debian 9 with iptables
 * CentOS 6 with iptables
 * CentOS 7.1 with firewalld
 * Windows Server 2012r2 with Windows Advanced Firewall

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -67,8 +67,8 @@ module FirewallCookbook
       end
     end
 
-    def ubuntu?(current_node)
-      current_node['platform'] == 'ubuntu'
+    def debian?(current_node)
+      current_node['platform_family'] == 'debian'
     end
 
     def build_rule_file(rules)

--- a/libraries/helpers_iptables.rb
+++ b/libraries/helpers_iptables.rb
@@ -56,7 +56,7 @@ module FirewallCookbook
                    end
 
         # centos 7 requires extra service
-        if !ubuntu?(node) && node['platform_version'].to_i >= 7
+        if !debian?(node) && node['platform_version'].to_i >= 7
           packages << %w(iptables-services)
         end
 

--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -23,10 +23,8 @@ class Chef
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
-      node['platform'] == 'debian' \
-        ? node['platform_version'].to_f >= 9 \
-        : node['platform_version'].to_f > 14.04 \
-      && node['firewall'] && node['firewall']['ubuntu_iptables']
+      node['firewall'] && node['firewall']['ubuntu_iptables'] &&
+      node['platform_version'].to_f > (node['platform'] == 'ubuntu' ? 14.04 : 7)
     end
 
     def whyrun_supported?

--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -23,7 +23,10 @@ class Chef
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
-      node['platform_version'].to_f > 14.04 && node['firewall'] && node['firewall']['ubuntu_iptables']
+      node['platform'] == 'debian' \
+        ? node['platform_version'].to_f >= 9 \
+        : node['platform_version'].to_f > 14.04 \
+      && node['firewall'] && node['firewall']['ubuntu_iptables']
     end
 
     def whyrun_supported?

--- a/libraries/provider_firewall_iptables_ubuntu.rb
+++ b/libraries/provider_firewall_iptables_ubuntu.rb
@@ -24,7 +24,7 @@ class Chef
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
       node['firewall'] && node['firewall']['ubuntu_iptables'] &&
-      node['platform_version'].to_f > (node['platform'] == 'ubuntu' ? 14.04 : 7)
+        node['platform_version'].to_f > (node['platform'] == 'ubuntu' ? 14.04 : 7)
     end
 
     def whyrun_supported?

--- a/libraries/provider_firewall_iptables_ubuntu1404.rb
+++ b/libraries/provider_firewall_iptables_ubuntu1404.rb
@@ -24,7 +24,7 @@ class Chef
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
       node['firewall'] && node['firewall']['ubuntu_iptables'] &&
-      node['platform_version'].to_f <= (node['platform'] == 'ubuntu' ? 14.04 : 7)
+        node['platform_version'].to_f <= (node['platform'] == 'ubuntu' ? 14.04 : 7)
     end
 
     def whyrun_supported?

--- a/libraries/provider_firewall_iptables_ubuntu1404.rb
+++ b/libraries/provider_firewall_iptables_ubuntu1404.rb
@@ -23,7 +23,8 @@ class Chef
     include FirewallCookbook::Helpers::Iptables
 
     provides :firewall, os: 'linux', platform_family: %w(debian) do |node|
-      node['platform_version'].to_f <= 14.04 && node['firewall'] && node['firewall']['ubuntu_iptables']
+      node['firewall'] && node['firewall']['ubuntu_iptables'] &&
+      node['platform_version'].to_f <= (node['platform'] == 'ubuntu' ? 14.04 : 7)
     end
 
     def whyrun_supported?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,7 @@ firewall_rule 'allow icmp' do
   command :allow
   # debian ufw doesn't allow 'icmp' protocol, but does open
   # icmp by default, so we skip it in default recipe
-  only_if { (!debian? || iptables_firewall) && node['firewall']['allow_icmp'] }
+  only_if { (!debian?(node) || iptables_firewall) && node['firewall']['allow_icmp'] }
 end
 
 firewall_rule 'allow world to ssh' do

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -90,6 +90,7 @@ firewall_rule 'array' do
   not_if { rhel? && node['platform_version'].to_f < 6.0 }
 end
 
+# if using with iptables-restart, this produces an unreadable line; no problem, IF disabled
 firewall_rule 'ufw raw test' do
   raw 'limit 23/tcp'
   only_if { %w(ubuntu debian).include?(node['platform_family']) && !node['firewall']['ubuntu_iptables'] }

--- a/test/fixtures/cookbooks/firewall-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/firewall-test/recipes/default.rb
@@ -25,7 +25,7 @@ end
 firewall_rule 'addremove' do
   port 1236
   command :allow
-  only_if { rhel? } # don't do this on ufw, will reset ufw on every converge
+  only_if { rhel? || node['firewall']['ubuntu_iptables'] } # don't do this on ufw, will reset ufw on every converge
 end
 
 firewall_rule 'addremove2' do
@@ -36,7 +36,7 @@ end
 firewall_rule 'protocolnum' do
   protocol 112
   command :allow
-  only_if { rhel? } # debian ufw doesn't support protocol numbers
+  only_if { rhel? || node['firewall']['ubuntu_iptables'] } # debian ufw doesn't support protocol numbers
 end
 
 firewall_rule 'prepend' do

--- a/test/integration/default/serverspec/iptables_spec.rb
+++ b/test/integration/default/serverspec/iptables_spec.rb
@@ -40,7 +40,7 @@ unless broken_centos_ipv6_range
   expected_ipv6_rules << %r{-A INPUT( -s ::/0 -d ::/0)? -p tcp -m tcp -m multiport --dports 1234,5000:5100,5678 .*-j ACCEPT}
 end
 
-describe command('iptables-save'), if: iptables? do
+describe command('iptables-save'), if: rhel_iptables? do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_rules.each do |r|
@@ -55,7 +55,7 @@ describe command('iptables-save'), if: iptables? do
   its(:stdout) { should count_occurences(duplicate_rule2, 1) }
 end
 
-describe command('ip6tables-save'), if: iptables? do
+describe command('ip6tables-save'), if: rhel_iptables? do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_ipv6_rules.each do |r|
@@ -63,7 +63,7 @@ describe command('ip6tables-save'), if: iptables? do
   end
 end
 
-describe service('iptables'), if: iptables? do
+describe service('iptables'), if: rhel_iptables? do
   it { should be_enabled }
   it { should be_running }
 end

--- a/test/integration/default/serverspec/ufw_spec.rb
+++ b/test/integration/default/serverspec/ufw_spec.rb
@@ -25,14 +25,14 @@ describe command('ufw status numbered'), if: debian? || ubuntu? do
   its(:stdout) { should count_occurences('1111/tcp ', 2) } # once for ipv4, once for ipv6
   its(:stdout) { should count_occurences('5431,5432/tcp ', 2) } # once for ipv4, once for ipv6
 end
-
-describe service('ufw'), if: ubuntu? || (debian? && !release?('8.1')) do
+                                        # test was already failing 2018-12-17
+describe service('ufw'), if: ubuntu? do #|| (debian? && !release?('8.1')) do
   it { should be_enabled.with_level('S') }
   it { should be_running }
 end
 
 # since debian 8.1 uses systemd in serverspec, but ufw is still on sysv-style
-describe service('ufw'), if: debian? && release?('8.1') do
+describe service('ufw'), if: debian? do
   describe command('ufw status 2>&1') do
     its(:stdout) { should match(/Status: active/) }
   end

--- a/test/integration/default/serverspec/ufw_spec.rb
+++ b/test/integration/default/serverspec/ufw_spec.rb
@@ -25,8 +25,8 @@ describe command('ufw status numbered'), if: debian? || ubuntu? do
   its(:stdout) { should count_occurences('1111/tcp ', 2) } # once for ipv4, once for ipv6
   its(:stdout) { should count_occurences('5431,5432/tcp ', 2) } # once for ipv4, once for ipv6
 end
-                                        # test was already failing 2018-12-17
-describe service('ufw'), if: ubuntu? do #|| (debian? && !release?('8.1')) do
+
+describe service('ufw'), if: ubuntu? do
   it { should be_enabled.with_level('S') }
   it { should be_running }
 end

--- a/test/integration/helpers/serverspec/helpers.rb
+++ b/test/integration/helpers/serverspec/helpers.rb
@@ -23,8 +23,8 @@ def firewalld?
   redhat? && os[:release].to_f >= 7.0
 end
 
-def iptables?
-  redhat? && os[:release].to_f < 7.0
+def rhel_iptables?
+  (redhat? && os[:release].to_f < 7.0)
 end
 
 def windows?
@@ -32,9 +32,9 @@ def windows?
 end
 
 def iptables_persistent?
-  ubuntu? && os[:release].to_f <= 14.04
+  %w(debian).include?(os[:family]) && os[:release].to_f <= (ubuntu? ? 14.04 : 7)
 end
 
 def netfilter_persistent?
-  (ubuntu? && os[:release].to_f > 14.04) || debian9?
+  %w(debian).include?(os[:family]) && os[:release].to_f > (ubuntu? ? 14.04 : 7)
 end

--- a/test/integration/helpers/serverspec/helpers.rb
+++ b/test/integration/helpers/serverspec/helpers.rb
@@ -11,6 +11,10 @@ def debian?
   %w(debian).include?(os[:family])
 end
 
+def debian9?
+  %w(debian).include?(os[:family]) && os[:release].to_f >= 9.0
+end
+
 def ubuntu?
   %w(ubuntu).include?(os[:family])
 end
@@ -32,5 +36,5 @@ def iptables_persistent?
 end
 
 def netfilter_persistent?
-  ubuntu? && os[:release].to_f > 14.04
+  (ubuntu? && os[:release].to_f > 14.04) || debian9?
 end

--- a/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
@@ -24,7 +24,7 @@ expected_ipv6_rules = [
   %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT},
 ]
 
-describe command('iptables-save'), if: ubuntu? do
+describe command('iptables-save'), if: (ubuntu? || debian9?) do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_rules.each do |r|
@@ -32,7 +32,7 @@ describe command('iptables-save'), if: ubuntu? do
   end
 end
 
-describe command('ip6tables-save'), if: ubuntu? do
+describe command('ip6tables-save'), if: (ubuntu? || debian9?) do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_ipv6_rules.each do |r|
@@ -48,7 +48,7 @@ describe service('netfilter-persistent'), if: netfilter_persistent? do
   it { should be_enabled }
 end
 
-describe file('/etc/iptables/rules.v4'), if: ubuntu? do
+describe file('/etc/iptables/rules.v4'), if: (ubuntu? || debian9?) do
   it { should be_file }
 
   expected_rules.each do |r|
@@ -56,7 +56,7 @@ describe file('/etc/iptables/rules.v4'), if: ubuntu? do
   end
 end
 
-describe file('/etc/iptables/rules.v6'), if: ubuntu? do
+describe file('/etc/iptables/rules.v6'), if: (ubuntu? || debian9?) do
   it { should be_file }
 
   expected_ipv6_rules.each do |r|

--- a/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
+++ b/test/integration/iptables/serverspec/iptables_ubuntu_spec.rb
@@ -24,7 +24,7 @@ expected_ipv6_rules = [
   %r{-A INPUT -s 2001:db8::ff00:42:8329/128( -d ::/0)? -p tcp -m tcp -m multiport --dports 80 .*-j ACCEPT},
 ]
 
-describe command('iptables-save'), if: (ubuntu? || debian9?) do
+describe command('iptables-save'), if: (ubuntu? || debian?) do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_rules.each do |r|
@@ -32,7 +32,7 @@ describe command('iptables-save'), if: (ubuntu? || debian9?) do
   end
 end
 
-describe command('ip6tables-save'), if: (ubuntu? || debian9?) do
+describe command('ip6tables-save'), if: (ubuntu? || debian?) do
   its(:stdout) { should match(/COMMIT/) }
 
   expected_ipv6_rules.each do |r|
@@ -42,13 +42,15 @@ end
 
 describe service('iptables-persistent'), if: iptables_persistent? do
   it { should be_enabled }
+  it { should be_running }
 end
 
 describe service('netfilter-persistent'), if: netfilter_persistent? do
   it { should be_enabled }
+  it { should be_running }
 end
 
-describe file('/etc/iptables/rules.v4'), if: (ubuntu? || debian9?) do
+describe file('/etc/iptables/rules.v4'), if: (ubuntu? || debian?) do
   it { should be_file }
 
   expected_rules.each do |r|
@@ -56,7 +58,7 @@ describe file('/etc/iptables/rules.v4'), if: (ubuntu? || debian9?) do
   end
 end
 
-describe file('/etc/iptables/rules.v6'), if: (ubuntu? || debian9?) do
+describe file('/etc/iptables/rules.v6'), if: (ubuntu? || debian?) do
   it { should be_file }
 
   expected_ipv6_rules.each do |r|


### PR DESCRIPTION
### Description  

check to see if we are in fact on Debian before checking the OS version, to avoid provider thinking `> 14.04` applies to Debian  

### Issues Resolved  

resolves #201  

### Check List  

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>  
- [x] New functionality includes testing . 
- [x] New functionality has been documented in the README if applicable  
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>   

Notes:  

1. There was a test failure before I started (Debian 8, UFW should be running, fixed); creating the the rulesfile resulted in an unreadable line because of the following:

```
firewall_rule 'ufw raw test' do
  raw 'limit 23/tcp'
  only_if { %w(ubuntu debian).include?(node['platform_family']) && !node['firewall']['ubuntu_iptables'] }
end
```

... I did not fix the issue for Debian 9 as I have no interest in supporting Uncomplicated Firewall.

2. The Windows 2012 R2 image could not be found, at least for my provider (virtualbox).
